### PR TITLE
Update api.md

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,3 +1,3 @@
 # REST API
 
-View Rownd's API documentation [here](https://app.theneo.io/rownd/api).
+View Rownd's API documentation [here](https://app.rownd.io/api-docs).


### PR DESCRIPTION
The (gitbook) documentation points to https://app.theneo.io/rownd/api/Rownd_API as the API docs.
The dashboard points to https://app.rownd.io/api-docs as the API docs.
Should these be the same? I assumed so but maybe they are pointing to different things on purpose. I assumed the one hosted at rownd.io were more official and this change fixes the documentation to point to that.