### PR TITLE
include getAccessToken destructuring useRownd()

### DIFF
--- a/sdk-reference/web/react---next-js.mdx
+++ b/sdk-reference/web/react---next-js.mdx
@@ -56,7 +56,8 @@ import React from "react";
 import { useRownd } from "@rownd/react";
 
 export default function MyProtectedComponent(props) {
-  const { is_authenticated, user, requestSignIn } = useRownd();
+  const { is_authenticated, user, requestSignIn, getAccessToken } = useRownd();
+  const { } = useEffect()
 
   useEffect(() => {
     if (!is_authenticated) {

--- a/sdk-reference/web/react---next-js.mdx
+++ b/sdk-reference/web/react---next-js.mdx
@@ -57,7 +57,6 @@ import { useRownd } from "@rownd/react";
 
 export default function MyProtectedComponent(props) {
   const { is_authenticated, user, requestSignIn, getAccessToken } = useRownd();
-  const { } = useEffect()
 
   useEffect(() => {
     if (!is_authenticated) {


### PR DESCRIPTION
Small typo I noticed when working through the react docs.  `getAccessToken` wasn't included in the hook object destructing.  

Love the product and excited to integrate it into my apps!  Just met Jim at Fed Supernova.